### PR TITLE
Add segmentation in retrieval scripts #21

### DIFF
--- a/bin/basic_test.py
+++ b/bin/basic_test.py
@@ -107,7 +107,11 @@ if __name__ == '__main__':
 
     # Test the model
     if segmentation:
-        test_model(modelpath=model, ifile=ifile, layers_dropped=layers_dropped,
-                   test_segmentation=True)
+        d, p = test_model(modelpath=model, ifile=ifile,
+                          layers_dropped=layers_dropped,
+                          test_segmentation=True)
     else:
-        test_model(modelpath=model, ifile=ifile, layers_dropped=layers_dropped)
+        d, p = test_model(modelpath=model, ifile=ifile,
+                          layers_dropped=layers_dropped)
+
+    #print(numpy.mean(p[:, 3]))

--- a/bin/basic_test.py
+++ b/bin/basic_test.py
@@ -5,7 +5,7 @@ from dataloading.dataloading import FeatureExtractorDataset
 from lib.training import test
 from utils.model_editing import drop_layers
 import config
-
+import numpy
 
 def test_model(modelpath, ifile, layers_dropped,
                test_segmentation=False, verbose=True):
@@ -78,7 +78,7 @@ Returns:
         print("--> Unormalized posteriors:\n {}\n".format(posteriors))
         print("--> Predictions:\n {}".format(y_pred))
 
-    return y_pred, posteriors
+    return y_pred, numpy.array(posteriors)
 
 
 if __name__ == '__main__':

--- a/bin/deep_retrieval_build_db.py
+++ b/bin/deep_retrieval_build_db.py
@@ -57,9 +57,8 @@ def compile_deep_database(data_folder, models_folder, db_path):
     for a in audio_files:
         f, f_temporal, f_names = get_meta_features(a, models)
         all_features.append(f)
-        all_features_temporal.append(f_temporal)
+        all_features_temporal.append(np.concatenate(f_temporal, axis=1).transpose())
     all_features = np.array(all_features)
-    all_features_temporal = np.array(all_features_temporal)
 
     with open(db_path, 'wb') as f:
         pickle.dump(all_features, f)

--- a/bin/deep_retrieval_build_db.py
+++ b/bin/deep_retrieval_build_db.py
@@ -4,74 +4,12 @@ from torch.utils.data import DataLoader
 from dataloading.dataloading import FeatureExtractorDataset
 from lib.training import test
 from utils.model_editing import drop_layers
+from basic_test import test_model
 import config
 import os
 import glob
 import numpy as np
 import pickle
-
-
-def test_model(modelpath, ifile, layers_dropped, ** kwargs):
-    """Loads a model and predicts each classes probability
-
-Arguments:
-
-        modelpath {str} : A path where the model was stored.
-
-        ifile {str} : A path of a given wav file,
-                      which will be tested.
-
-Returns:
-
-        y_pred {np.array} : An array with the probability of each class
-                            that the model predicts.
-
-    """
-
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    # Restore model
-    if device == "cpu":
-        model = torch.load(modelpath, map_location=torch.device('cpu'))
-    else:
-        model = torch.load(modelpath)
-    max_seq_length = model.max_sequence_length
-
-    # Apply layer drop
-    model = drop_layers(model, layers_dropped)
-    model.max_sequence_length = max_seq_length
-
-    zero_pad = model.zero_pad
-    spec_size = model.spec_size
-    fuse = model.fuse
-
-#    print('Model:\n{}'.format(model))
-
-    # Move to device
-    model.to(device)
-
-    # Create test set
-    test_set = FeatureExtractorDataset(X=[ifile],
-                                       # Random class -- does not matter at all
-                                       y=[0],
-                                       fe_method="MEL_SPECTROGRAM",
-                                       oversampling=False,
-                                       max_sequence_length=max_seq_length,
-                                       zero_pad=zero_pad,
-                                       forced_size=spec_size,
-                                       fuse=fuse,
-                                       show_hist=False)
-
-    # Create test dataloader
-    test_loader = DataLoader(dataset=test_set, batch_size=1,
-                             num_workers=4, drop_last=False,
-                             shuffle=False)
-
-    # Forward a sample
-    out, y_pred, _ = test(model=model, dataloader=test_loader,
-                       cnn=True,
-                       classifier=True if layers_dropped == 0 else False)
-
-    return out[0], y_pred[0]
 
 
 def load_models(models_path):
@@ -89,9 +27,16 @@ def get_meta_features(audio_file, list_of_models):
     feature_names = []
     features = np.array([])
     for m in list_of_models:
-        soft, r = test_model(modelpath=m,
+        r, soft = test_model(modelpath=m,
                              ifile=audio_file,
-                             layers_dropped=layers_dropped)
+                             layers_dropped=layers_dropped,
+                             test_segmentation=True,
+                             verbose=True)
+        # long-term average the posteriors
+        # (along different CNN segment-decisions)
+        soft_average = np.mean(soft, axis=0)
+        soft = soft_average
+
         features = np.concatenate([features, soft])
         feature_names += [f'{os.path.basename(m).replace(".pt", "")}_{i}'
                           for i in range(len(soft))]

--- a/bin/deep_retrieval_query.py
+++ b/bin/deep_retrieval_query.py
@@ -25,8 +25,11 @@ def search_deep_database(database_path, query_wav):
     f, f_temp, f_names = deep_retrieval_build_db.get_meta_features(query_wav, models)
     print(all_features_temporal[0])
     d = scipy.spatial.distance.cdist(f.reshape(-1, 1).T, all_features)[0]
-    print([x for _, x in sorted(zip(d, audio_files))])
-    print(sorted(d))
+    file_sorted = ([x for _, x in sorted(zip(d, audio_files))])
+    distances_sorted = sorted(d)
+
+    for d, f in zip(file_sorted, distances_sorted):
+        print(f'{d} {f}')
 
 
 if __name__ == '__main__':

--- a/bin/deep_retrieval_query.py
+++ b/bin/deep_retrieval_query.py
@@ -16,6 +16,7 @@ import deep_retrieval_build_db
 def search_deep_database(database_path, query_wav):
     with open(database_path, 'rb') as f:
         all_features = pickle.load(f)
+        all_features_temporal = pickle.load(f)
         f_names = pickle.load(f)
         audio_files = pickle.load(f)
         models_folder = pickle.load(f)
@@ -26,7 +27,7 @@ def search_deep_database(database_path, query_wav):
     import scipy.spatial.distance
     print(f.reshape(-1,1).shape)
     print(all_features.shape)
-    d = scipy.spatial.distance.cdist(f.reshape(-1,1).T, all_features)[0]
+    d = scipy.spatial.distance.cdist(f.reshape(-1, 1).T, all_features)[0]
     print([x for _, x in sorted(zip(d, audio_files))])
     print(sorted(d))
 

--- a/bin/deep_retrieval_query.py
+++ b/bin/deep_retrieval_query.py
@@ -9,7 +9,7 @@ import os
 import glob
 import numpy as np
 import pickle
-
+import scipy.spatial.distance
 import deep_retrieval_build_db
 
 
@@ -22,11 +22,8 @@ def search_deep_database(database_path, query_wav):
         models_folder = pickle.load(f)
 
     models = deep_retrieval_build_db.load_models(models_folder)
-    f, f_names = deep_retrieval_build_db.get_meta_features(query_wav, models)
-
-    import scipy.spatial.distance
-    print(f.reshape(-1,1).shape)
-    print(all_features.shape)
+    f, f_temp, f_names = deep_retrieval_build_db.get_meta_features(query_wav, models)
+    print(all_features_temporal[0])
     d = scipy.spatial.distance.cdist(f.reshape(-1, 1).T, all_features)[0]
     print([x for _, x in sorted(zip(d, audio_files))])
     print(sorted(d))

--- a/dataloading/dataloading.py
+++ b/dataloading/dataloading.py
@@ -199,10 +199,11 @@ class FeatureExtractorDataset(Dataset):
         X = self.features.copy()
         X_resized = []
         for x in X:
-            spec = Image.fromarray(x)
-            spec = spec.resize(spec_size)
-            spec = np.array(spec)
-            X_resized.append(spec)
+            if x.shape[0] >0 :
+                spec = Image.fromarray(x)
+                spec = spec.resize(spec_size)
+                spec = np.array(spec)
+                X_resized.append(spec)
         return X_resized
 
     @staticmethod

--- a/dataloading/dataloading.py
+++ b/dataloading/dataloading.py
@@ -197,14 +197,14 @@ class FeatureExtractorDataset(Dataset):
             spec_size = self.spec_size
 
         X = self.features.copy()
-        X_resized = []
+        x_resized = []
         for x in X:
-            if x.shape[0] >0 :
+            if x.shape[0] > 0:
                 spec = Image.fromarray(x)
                 spec = spec.resize(spec_size)
                 spec = np.array(spec)
-                X_resized.append(spec)
-        return X_resized
+                x_resized.append(spec)
+        return x_resized
 
     @staticmethod
     def group_data_by_label(spec_sizes, labels):


### PR DESCRIPTION
@lobracost please do a quick QA.
Instructions:
 - use 10-20 songs as a db collection (say stored in collection_path)
 - use 4 cnn pertained models (say stored in models_path) 
 - build the db: python3 bin/deep_retrieval_build_db.py -m models_path -i collection_path
 - run some example queries (u can even use songs from the db for sanity check): python3 bin/deep_retrieval_query.py -d db -I some_song.wav