### PR TITLE
Change model saving and loading

### DIFF
--- a/deep_audio_features/bin/basic_test.py
+++ b/deep_audio_features/bin/basic_test.py
@@ -5,6 +5,7 @@ import sys, os
 sys.path.insert(0, os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "../../"))
 from deep_audio_features.dataloading.dataloading import FeatureExtractorDataset
+from deep_audio_features.models.cnn import load_cnn
 from deep_audio_features.lib.training import test
 from deep_audio_features.utils.model_editing import drop_layers
 import deep_audio_features.bin.config
@@ -35,10 +36,7 @@ Returns:
     """
     device = "cuda" if torch.cuda.is_available() else "cpu"
     # Restore model
-    if device == "cpu":
-        model = torch.load(modelpath, map_location=torch.device('cpu'))
-    else:
-        model = torch.load(modelpath)
+    model = load_cnn(modelpath).to(device)
 
     max_seq_length = model.max_sequence_length
 

--- a/deep_audio_features/bin/basic_training.py
+++ b/deep_audio_features/bin/basic_training.py
@@ -13,6 +13,7 @@ model is saved in pkl folder (exact filename is printed after training)
 import argparse
 import os
 import time
+import pickle
 import torch
 from torch.utils.data import DataLoader
 import sys, os
@@ -156,7 +157,15 @@ def train_model(folders=None, ofile=None, zero_pad=ZERO_PAD,
 
     print(f"\nSaving model to: {modelname}\n")
     # Save model for later use
-    torch.save(best_model, modelname)
+    model_params = {
+        "height": height, "width": width, "output_dim": len(classes),
+        "zero_pad": zero_pad, "spec_size": spec_size, "fuse": FUSED_SPECT,
+        "validation_f1": best_model_f1, "max_sequence_length": max_seq_length,
+        "type": best_model.type, "state_dict": best_model.state_dict()
+    }
+
+    with open(modelname, "wb") as output_file:
+        pickle.dump(model_params, output_file)
 
 
 if __name__ == '__main__':

--- a/deep_audio_features/bin/basic_training.py
+++ b/deep_audio_features/bin/basic_training.py
@@ -156,6 +156,7 @@ def train_model(folders=None, ofile=None, zero_pad=ZERO_PAD,
 
 
     print(f"\nSaving model to: {modelname}\n")
+    best_model = best_model.to("cpu")
     # Save model for later use
     model_params = {
         "height": height, "width": width, "output_dim": len(classes),

--- a/deep_audio_features/bin/classification_report.py
+++ b/deep_audio_features/bin/classification_report.py
@@ -1,10 +1,12 @@
 import argparse
 import os
-from utils import load_dataset
+import pickle
+from deep_audio_features.utils import load_dataset
 import torch
 from torch.utils.data import DataLoader
-from dataloading.dataloading import FeatureExtractorDataset
-from lib.training import test
+from deep_audio_features.dataloading.dataloading import FeatureExtractorDataset
+from deep_audio_features.models.cnn import CNN1
+from deep_audio_features.lib.training import test
 from sklearn.metrics import classification_report
 import config
 
@@ -12,7 +14,15 @@ import config
 def test_report(modelpath, folders, layers_dropped):
 
 
-    model = torch.load(modelpath)
+    #model = torch.load(modelpath)
+    with open(modelpath, "rb") as input_file:
+        model_params = pickle.load(input_file)
+
+    model = CNN1(height=model_params["height"], width=model_params["width"], output_dim=model_params["output_dim"],
+                 zero_pad=model_params["zero_pad"], spec_size=model_params["spec_size"], fuse=model_params["fuse"], type=model_params["type"])
+    model.max_sequence_length = model_params["max_sequence_length"]
+    model.load_state_dict(model_params["state_dict"])
+
     max_seq_length = model.max_sequence_length
     files_test, y_test = load_dataset.load(
         folders=folders, test=False, validation=False)

--- a/deep_audio_features/bin/classification_report.py
+++ b/deep_audio_features/bin/classification_report.py
@@ -1,27 +1,21 @@
 import argparse
 import os
-import pickle
-from deep_audio_features.utils import load_dataset
 import torch
+import sys
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "../../"))
 from torch.utils.data import DataLoader
 from deep_audio_features.dataloading.dataloading import FeatureExtractorDataset
-from deep_audio_features.models.cnn import CNN1
+from deep_audio_features.utils import load_dataset
 from deep_audio_features.lib.training import test
+from deep_audio_features.models.cnn import load_cnn
 from sklearn.metrics import classification_report
 import config
 
 
-def test_report(modelpath, folders, layers_dropped):
+def test_report(model_path, folders, layers_dropped):
 
-
-    #model = torch.load(modelpath)
-    with open(modelpath, "rb") as input_file:
-        model_params = pickle.load(input_file)
-
-    model = CNN1(height=model_params["height"], width=model_params["width"], output_dim=model_params["output_dim"],
-                 zero_pad=model_params["zero_pad"], spec_size=model_params["spec_size"], fuse=model_params["fuse"], type=model_params["type"])
-    model.max_sequence_length = model_params["max_sequence_length"]
-    model.load_state_dict(model_params["state_dict"])
+    model = load_cnn(model_path)
 
     max_seq_length = model.max_sequence_length
     files_test, y_test = load_dataset.load(
@@ -71,7 +65,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # Get arguments
-    model = args.model
+    model_path = args.model
     folders = args.input
 
     layers_dropped = int(args.layers)
@@ -85,4 +79,4 @@ if __name__ == '__main__':
             raise FileNotFoundError()
 
     # Test the model
-    test_report(model, folders, layers_dropped)
+    test_report(model_path, folders, layers_dropped)

--- a/deep_audio_features/bin/transfer_learning.py
+++ b/deep_audio_features/bin/transfer_learning.py
@@ -15,11 +15,13 @@ import os
 import time
 import torch
 import sys
+import pickle
 from torch.utils.data import DataLoader
 
 sys.path.insert(0, os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "../../"))
 
+from deep_audio_features.models.cnn import load_cnn
 from deep_audio_features.bin.config import EPOCHS, CNN_BOOLEAN, VARIABLES_FOLDER, ZERO_PAD, \
     FORCE_SIZE, SPECTOGRAM_SIZE, FEATURE_EXTRACTION_METHOD, OVERSAMPLING, \
     FUSED_SPECT, BATCH_SIZE
@@ -53,10 +55,11 @@ def transfer_learning(model=None, folders=None, strategy=0,
     # and load it to 'cpu' to get some free GPU for Dataloaders
     if isinstance(model, str):
         print('Loading model...')
-        model = torch.load(model, map_location='cpu')
+        model = load_cnn(model)
     else:
         print('Model already loaded...\nMoving it to CPU...')
-        model.to('cpu')
+
+    model.to('cpu')
 
     # Get max_seq_length from the model
     max_seq_length = model.max_sequence_length

--- a/deep_audio_features/bin/transfer_learning.py
+++ b/deep_audio_features/bin/transfer_learning.py
@@ -142,7 +142,17 @@ def transfer_learning(model=None, folders=None, strategy=0,
         VARIABLES_FOLDER, model_id)
     print(f"\nSaving model to: {model_id}\n")
     # Save model for later use
-    torch.save(best_model, modelname)
+    # torch.save(best_model, modelname)
+
+    model_params = {
+        "height": best_model.height, "width": best_model.width, "output_dim": best_model.output_dim,
+        "zero_pad": best_model.zero_pad, "spec_size": best_model.spec_size, "fuse": best_model.fuse,
+        "validation_f1": valid_f1, "max_sequence_length": best_model.max_sequence_length,
+        "type": best_model.type, "state_dict": best_model.state_dict()
+    }
+
+    with open(modelname, "wb") as output_file:
+        pickle.dump(model_params, output_file)
 
 
 if __name__ == '__main__':

--- a/deep_audio_features/bin/transfer_learning.py
+++ b/deep_audio_features/bin/transfer_learning.py
@@ -145,7 +145,8 @@ def transfer_learning(model=None, folders=None, strategy=0,
         VARIABLES_FOLDER, model_id)
     print(f"\nSaving model to: {model_id}\n")
     # Save model for later use
-    # torch.save(best_model, modelname)
+
+    best_model = best_model.to("cpu")
 
     model_params = {
         "height": best_model.height, "width": best_model.width, "output_dim": best_model.output_dim,

--- a/deep_audio_features/combine/feature_extraction.py
+++ b/deep_audio_features/combine/feature_extraction.py
@@ -9,6 +9,7 @@ from pyAudioAnalysis import audioBasicIO as aIO
 import sys
 sys.path.insert(0, os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "../../"))
+from deep_audio_features.models.cnn import load_cnn
 from deep_audio_features.utils.load_dataset import folders_mapping
 from deep_audio_features.utils import get_models
 from deep_audio_features.dataloading.dataloading import FeatureExtractorDataset
@@ -227,6 +228,8 @@ def extraction(input, modification, folders=True, show_hist=True):
             List of pca models used for each CNN.
     """
 
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
     print('-----------------------------------------------------------------')
     n_components = modification['n_components']
     filenames = []
@@ -282,12 +285,10 @@ def extraction(input, modification, folders=True, show_hist=True):
 
         for j, model_path in enumerate(model_paths):
             print('--> Extracting features using model: {}'.format(model_path))
-            if torch.cuda.is_available():
-                model = copy.deepcopy(torch.load(model_path))
-            else:
-                model = copy.deepcopy(torch.load(
-                    model_path, map_location=torch.device('cpu')))
 
+            model = load_cnn(model_path)
+            model = copy.deepcopy(model)
+            model = model.to(device)
             model.type = 'feature_extractor'
 
             models.append(model)

--- a/deep_audio_features/models/cnn.py
+++ b/deep_audio_features/models/cnn.py
@@ -1,5 +1,7 @@
 import torch.nn as nn
-import sys, os
+import sys
+import os
+import pickle
 sys.path.insert(0, os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "../../"))
 from deep_audio_features.bin.config import SPECTOGRAM_SIZE
@@ -17,6 +19,7 @@ class CNN1(nn.Module):
         self.type = type
         self.num_cnn_layers = 4
         self.cnn_channels = 2
+        self.output_dim = output_dim
         self.height = height
         self.width = width
         self.first_channels = first_channels
@@ -97,3 +100,16 @@ class CNN1(nn.Module):
         kernels = (self.cnn_channels ** (self.num_cnn_layers - 1)) *\
             self.first_channels
         return kernels * height * width
+
+
+def load_cnn(model_path):
+    with open(model_path, "rb") as input_file:
+        model_params = pickle.load(input_file)
+
+    model = CNN1(height=model_params["height"], width=model_params["width"], output_dim=model_params["output_dim"],
+                 zero_pad=model_params["zero_pad"], spec_size=model_params["spec_size"], fuse=model_params["fuse"],
+                 type=model_params["type"])
+    model.max_sequence_length = model_params["max_sequence_length"]
+    model.load_state_dict(model_params["state_dict"])
+
+    return model

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requirements = read('requirements.txt').splitlines()
 
 
 setup(name='deep_audio_features',
-      version='0.1.8',
+      version='0.1.9',
       description='Extract supervised deep features using CNN audio classifiers',
       url='https://github.com/tyiannak/deep_audio_features',
       author='Theodoros Giannakopoulos',


### PR DESCRIPTION
This PR aims to address the model saving and loading issue and thus resolves #24. More specifically, the entire model object has been saved in previous code versions. That object is attached to a specific directory and code structure, making it impossible to run old models using newer code versions. 

In contrast to this method, the proposed solution stores the model's state dictionary (state_dict) which is a dictionary containing the model structure explicitly. In this way, it is ensured that newly trained models will run in future code versions.

The basic loading functionality, instead of just torch.load(object_file), is achieved through the newly introduced load_cnn function https://github.com/tyiannak/deep_audio_features/blob/e414f37cccccd4b24c58e025c83d20f2093c0b4e/deep_audio_features/models/cnn.py#L105-L115

How to QA:

Unfortunately, the functionality of the code is strongly dependent on saving and loading models, so we have to ensure that all scripts (train, test, transfer learning, combine) can be run correctly.