### PR TITLE
fixing classification report

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ spectrogram representations from the respective sounds, trains and validates the
 trained model in `pkl/energy.pt`
 
 ### 3.2 Testing a CNN
-
+#### 3.2.1 Inference
+To perform inference for one file only, run:
 ```
 python3 deep_audio_features/bin/basic_test.py -m /path/to/model/ -i /path/to/file (-s)
 ```
-`-i` : select the folders  where the testing data will be loaded from.
+`-i` : select the file where the testing data will be loaded from.
 
 `-m` : select a model to apply testing.
 
@@ -58,6 +59,21 @@ The code above will use the CNN trained befre to classify an audio signal stored
 `d` stores the decision (class indices) and `p` the soft outputs of the classes. 
 If `layers_dropped` is positive, `d` is empty an `p` contains the outputs of the N-layers_dropped layer (N is the total number of layers in the CNN).
 E.g. if `layers_dropped`, `p` will contain the outputs of the last fully connected layer, before softmax.
+
+#### 3.2.2 Evaluate on new data
+To perform evaluation on different data, run:
+```
+python3 deep_audio_features/bin/classification_report.py -m /path/to/model/ -i /path/to/folder1 /path/to/folder2
+```
+`-i` : select the folders where the testing data will be loaded from.
+
+`-m` : select a model to apply testing.
+
+Or call the following function in Python:
+```python
+from deep_audio_features.bin import classification_report as creport
+creport.test_report("/path/to/model/", ["low","medium","high"], layers_dropped=0)
+```
 
 ### 3.3 Transfer learning 
 

--- a/deep_audio_features/bin/classification_report.py
+++ b/deep_audio_features/bin/classification_report.py
@@ -13,6 +13,7 @@ from deep_audio_features.utils import load_dataset
 from deep_audio_features.lib.training import test
 from deep_audio_features.models.cnn import load_cnn
 from sklearn.metrics import classification_report
+from sklearn.metrics import confusion_matrix
 from deep_audio_features.bin import config
 
 
@@ -56,6 +57,9 @@ def test_report(model_path, folders, layers_dropped):
     _, y_pred, y_true = test(model=model, dataloader=test_loader,
                        cnn=True,
                        classifier=True if layers_dropped == 0 else False)
+
+    cm = confusion_matrix(y_true, y_pred)
+    print("Confusion matrix:\n {}".format(cm))
 
     report = classification_report(y_true, y_pred)
     print("Classification report: ")

--- a/deep_audio_features/bin/classification_report.py
+++ b/deep_audio_features/bin/classification_report.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import torch
 import sys
+import pickle
 import torch.multiprocessing
 torch.multiprocessing.set_sharing_strategy('file_system')
 sys.path.insert(0, os.path.join(
@@ -20,12 +21,16 @@ def test_report(model_path, folders, layers_dropped):
     in order to run on a big amount of data, since due to batch_size = 1,
     the share strategy used in torch.multiprocessing results in memory errors
     """
+    with open(model_path, "rb") as input_file:
+        model_params = pickle.load(input_file)
+    class_mapping = model_params["classes_mapping"]
 
     model, hop_length, window_length = load_cnn(model_path)
 
     max_seq_length = model.max_sequence_length
-    files_test, y_test = load_dataset.load(
-        folders=folders, test=False, validation=False)
+    files_test, y_test, class_mapping = load_dataset.load(
+        folders=folders, test=False,
+        validation=False, class_mapping=class_mapping)
 
     spec_size = model.spec_size
     zero_pad = model.zero_pad

--- a/deep_audio_features/bin/classification_report.py
+++ b/deep_audio_features/bin/classification_report.py
@@ -61,6 +61,8 @@ def test_report(model_path, folders, layers_dropped):
     cm = confusion_matrix(y_true, y_pred)
     print("Confusion matrix:\n {}".format(cm))
 
+    y_true = [class_mapping[y] for y in y_true]
+    y_pred = [class_mapping[y] for y in y_pred]
     report = classification_report(y_true, y_pred)
     print("Classification report: ")
     print(report)

--- a/deep_audio_features/utils/load_dataset.py
+++ b/deep_audio_features/utils/load_dataset.py
@@ -10,7 +10,9 @@ import wave
 import contextlib
 from collections import Counter
 
-def load(folders=None, test_val=[0.2, 0.2], test=True, validation=True):
+
+def load(folders=None, test_val=[0.2, 0.2],
+         test=True, validation=True, class_mapping=None):
     """Loads a dataset from some folders.
 
     Arguments
@@ -42,6 +44,7 @@ def load(folders=None, test_val=[0.2, 0.2], test=True, validation=True):
         raise AssertionError()
     filenames = []
     labels = []
+    folders = sorted(folders)
 
     # Match filenames with labels
     for folder in folders:
@@ -51,7 +54,13 @@ def load(folders=None, test_val=[0.2, 0.2], test=True, validation=True):
 
     # Convert labels to int
     folder2idx, idx2folder = folders_mapping(folders=folders)
-
+    if class_mapping:
+        for k, v in idx2folder.items():
+            for k_2, v_2 in class_mapping.items():
+                if v_2 in v:
+                    idx2folder[k_2] = v
+        folder2idx = {v: k for k, v in idx2folder.items()}
+    print(folder2idx)
     labels = list(map(lambda x: folder2idx[x], labels))
     class_mapping = {name: idx2folder[name].split("/")[-1] for name in idx2folder}
     # Split
@@ -125,8 +134,13 @@ def compute_max_seq_len(reload=False, X=None, folders=None):
                          (config.HOP_LENGTH) + 1)
             lengths.append(length)
     # instead of computing the overall maximum we use the 90% percentile
-    max_seq = int(np.percentile(lengths, 90))
+    max_seq = int(np.max(lengths))
     print(f"Max sequence length in dataset: {max_seq}")
+    mean_seq = int(np.mean(lengths))
+    print(f"Mean sequence length in dataset: {mean_seq}")
+    std_seq = int(np.std(lengths))
+    print(f"Std of sequence lengths in dataset: {std_seq}")
+
     return max_seq
 
 

--- a/deep_audio_features/utils/load_dataset.py
+++ b/deep_audio_features/utils/load_dataset.py
@@ -60,7 +60,7 @@ def load(folders=None, test_val=[0.2, 0.2],
                 if v_2 in v:
                     idx2folder[k_2] = v
         folder2idx = {v: k for k, v in idx2folder.items()}
-    print(folder2idx)
+    
     labels = list(map(lambda x: folder2idx[x], labels))
     class_mapping = {name: idx2folder[name].split("/")[-1] for name in idx2folder}
     # Split

--- a/deep_audio_features/utils/load_dataset.py
+++ b/deep_audio_features/utils/load_dataset.py
@@ -60,7 +60,7 @@ def load(folders=None, test_val=[0.2, 0.2],
                 if v_2 in v:
                     idx2folder[k_2] = v
         folder2idx = {v: k for k, v in idx2folder.items()}
-    
+
     labels = list(map(lambda x: folder2idx[x], labels))
     class_mapping = {name: idx2folder[name].split("/")[-1] for name in idx2folder}
     # Split


### PR DESCRIPTION
This PR fixes the classification_report.py script in order to run as expected.

To QA:

Run ```python3 deep_audio_features/bin/classification_report.py -m <model> -i <folder1> <folder2> ```

The testing folders must have the same basename as the ones that the model was trained on, but no need to have the same order.