### PR TITLE
plot durations

### DIFF
--- a/deep_audio_features/bin/tool_plot_durations.py
+++ b/deep_audio_features/bin/tool_plot_durations.py
@@ -1,0 +1,54 @@
+import contextlib
+import wave
+import plotly.express as px
+import os
+import pandas as pd
+import argparse
+
+
+def get_wav_duration(fname):
+    with contextlib.closing(wave.open(fname,'r')) as f:
+        frames = f.getnframes()
+        rate = f.getframerate()
+        duration = frames / float(rate)
+        return duration
+
+
+def getListOfFiles(dirName):
+    listOfFile = os.listdir(dirName)
+    allFiles = []
+    for entry in listOfFile:
+        fullPath = os.path.join(dirName, entry)
+        if os.path.isdir(fullPath):
+            allFiles = allFiles + getListOfFiles(fullPath)
+        elif fullPath.endswith(('.wav', '.mp3')):
+            allFiles.append(fullPath)
+
+    return allFiles
+
+def plot_hist(dir):
+
+    file_list = getListOfFiles(dir)
+    durations = []
+    print('--> Calculating durations')
+    for file in file_list:
+        durations.append(get_wav_duration(file))
+    df = pd.DataFrame({'duration': durations})
+    print('--> Plotting histogram of audio durations')
+    fig = px.histogram(df, x="duration")
+    fig.update_layout(title_text='Audio durations in s', title_x=0.5)
+    fig.show()
+
+    fig.write_html(dir + "_durations.html")
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-i',
+                        '--input',
+                        type=str,
+                        required=True,
+                        default=None,
+                        help='Input directory')
+    FLAGS = parser.parse_args()
+    plot_hist(FLAGS.input)


### PR DESCRIPTION
This branch is responsible about creating a script to plot audio files durations in a histogram. 
In order to check run: 
`python3 deep_audio_features/bin/tool_plot_durations.py -i  file_dir` 
Where file_dir can either contain raw audios or subfolders of raw audios. 

Iemocap results: 
![Screenshot from 2022-01-04 16-53-30](https://user-images.githubusercontent.com/45540286/148077773-ee0bdb60-3fb3-4e1b-ad3f-dfeb8c0eb2e4.png)

Podcast results: 
![Audio_durations](https://user-images.githubusercontent.com/45540286/148077838-565fd0ca-3bf2-47e0-b78e-bc36cb54a554.png)
