### PR TITLE
Transfer learning refactoring #45

### DIFF
--- a/deep_audio_features/bin/tool_model_architecture.py
+++ b/deep_audio_features/bin/tool_model_architecture.py
@@ -1,0 +1,37 @@
+import pickle
+import argparse
+import os
+import sys
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "../../"))
+from deep_audio_features.models.convAE import load_convAE
+from deep_audio_features.models.cnn import load_cnn
+
+
+
+def print_model_architecture(modelpath):
+    print('Loading model...')
+    with open(modelpath, "rb") as input_file:
+        model_params = pickle.load(input_file)
+    if "classes_mapping" in model_params:
+        model, hop_length, window_length = load_cnn(modelpath)
+    else:
+        model, hop_length, window_length = load_convAE(modelpath)
+    print("Model architecture:\n", model)
+
+
+
+
+if __name__ == '__main__':
+    # Read arguments -- a list of folders
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-m', '--model', required=True, type=str,
+                        help='Model to apply tranfer learning.')
+
+    args = parser.parse_args()
+    modelpath = args.model
+
+    # Check that model file exists
+    if os.path.exists(modelpath) is False:
+        raise FileNotFoundError
+    print_model_architecture(modelpath)

--- a/deep_audio_features/bin/transfer_learning.py
+++ b/deep_audio_features/bin/transfer_learning.py
@@ -35,7 +35,7 @@ from deep_audio_features.dataloading.dataloading import FeatureExtractorDataset
 # sys.path.insert(0, '/'.join(os.path.abspath(__file__).split(' /')[:-2]))
 
 
-def transfer_learning(modelpath=None, folders=None, strategy=False,
+def transfer_learning(modelpath=None, ofile=None, folders=None, strategy=False,
                       zero_pad=ZERO_PAD, forced_size=None, layers_freezed=0):
     """Transfer learning from all folders given to a model."""
 
@@ -186,8 +186,12 @@ def transfer_learning(modelpath=None, folders=None, strategy=False,
         best_model_loss = valid_losses[best_index]
         print('Best model\'s validation loss: {}'.format(best_model_loss))
 
-
-    ofile = f"{best_model.__class__.__name__}_{_epochs}_{timestamp}.pt"
+    if ofile is None:
+        ofile = f"{best_model.__class__.__name__}_{_epochs}_{timestamp}.pt"
+    else:
+        ofile = str(ofile)
+        if '.pt' not in ofile or '.pkl' not in ofile:
+            ofile = ''.join([ofile, '.pt'])
 
     if not os.path.exists(VARIABLES_FOLDER):
         os.makedirs(VARIABLES_FOLDER)
@@ -229,7 +233,8 @@ if __name__ == '__main__':
 
     parser.add_argument('-l', '--layers_freezed', required=False, default=0,
                         type=int, help='Number of final layers to freeze their weights')
-
+    parser.add_argument('-o', '--ofile', required=False, default=None,
+                        type=str, help='Model name.')
     args = parser.parse_args()
 
     # Get argument
@@ -237,6 +242,7 @@ if __name__ == '__main__':
     modelpath = args.model
     strategy = args.strategy
     layers_freezed = args.layers_freezed
+    ofile = args.ofile
     # Fix any type errors
     folders = [f.replace(',', '').strip() for f in folders]
 
@@ -251,7 +257,7 @@ if __name__ == '__main__':
 
     # If everything is ok, time to start
     if FORCE_SIZE:
-        transfer_learning(modelpath=modelpath, folders=folders,
+        transfer_learning(modelpath=modelpath, ofile=ofile, folders=folders,
                           strategy=strategy, forced_size=SPECTOGRAM_SIZE, layers_freezed=layers_freezed)
     else:
-        transfer_learning(modelpath=modelpath, folders=folders, strategy=strategy, layers_freezed=layers_freezed)
+        transfer_learning(modelpath=modelpath, ofile=ofile, folders=folders, strategy=strategy, layers_freezed=layers_freezed)

--- a/deep_audio_features/bin/transfer_learning.py
+++ b/deep_audio_features/bin/transfer_learning.py
@@ -18,9 +18,10 @@ import sys
 import pickle
 from torch.utils.data import DataLoader
 
+
 sys.path.insert(0, os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "../../"))
-
+from deep_audio_features.models.convAE import load_convAE
 from deep_audio_features.models.cnn import load_cnn
 from deep_audio_features.bin.config import EPOCHS, CNN_BOOLEAN, VARIABLES_FOLDER, ZERO_PAD, \
     FORCE_SIZE, SPECTOGRAM_SIZE, FEATURE_EXTRACTION_METHOD, OVERSAMPLING, \
@@ -34,28 +35,36 @@ from deep_audio_features.dataloading.dataloading import FeatureExtractorDataset
 # sys.path.insert(0, '/'.join(os.path.abspath(__file__).split(' /')[:-2]))
 
 
-def transfer_learning(model=None, folders=None, strategy=0,
-                      zero_pad=ZERO_PAD, forced_size=None):
+def transfer_learning(modelpath=None, folders=None, strategy=False,
+                      zero_pad=ZERO_PAD, forced_size=None, layers_freezed=0):
     """Transfer learning from all folders given to a model."""
 
     # Arguments check
     if folders is None:
         raise FileNotFoundError()
 
-    if model is None:
+    if modelpath is None:
         raise FileNotFoundError()
 
-    if not isinstance(strategy, int):
-        raise AttributeError("variable `strategy` should be int !")
+
+    if not isinstance(layers_freezed, int):
+        raise AttributeError("variable `layers_freezed` should be int !")
 
     # Create classes
-    classes = [os.path.basename(f) for f in folders]
+    #classes = [os.path.basename(f) for f in folders]
 
     # Check if the model is already loaded
     # and load it to 'cpu' to get some free GPU for Dataloaders
-    if isinstance(model, str):
+    if isinstance(modelpath, str):
         print('Loading model...')
-        model, hop_length, window_length = load_cnn(model)
+        with open(modelpath, "rb") as input_file:
+            model_params = pickle.load(input_file)
+        if "classes_mapping" in model_params:
+            task = "classification"
+            model, hop_length, window_length = load_cnn(modelpath)
+        else:
+            task = "representation"
+            model, hop_length, window_length = load_convAE(modelpath)
     else:
         print('Model already loaded...\nMoving it to CPU...')
 
@@ -64,6 +73,8 @@ def transfer_learning(model=None, folders=None, strategy=0,
     # Get max_seq_length from the model
     max_seq_length = model.max_sequence_length
     print(f"Setting max sequence length: {max_seq_length}...")
+    zero_pad = model.zero_pad
+    fuse = model.fuse
 
     # Use data only for training and validation
     files_train, y_train, files_eval, y_eval, classes_mapping = load_dataset.load(
@@ -83,7 +94,7 @@ def transfer_learning(model=None, folders=None, strategy=0,
                                         max_sequence_length=max_seq_length,
                                         zero_pad=zero_pad,
                                         forced_size=spec_size,
-                                        fuse=FUSED_SPECT,
+                                        fuse=fuse,
                                         hop_length=hop_length, window_length=window_length)
 
     eval_set = FeatureExtractorDataset(X=files_eval, y=y_eval,
@@ -92,7 +103,7 @@ def transfer_learning(model=None, folders=None, strategy=0,
                                        max_sequence_length=max_seq_length,
                                        zero_pad=zero_pad,
                                        forced_size=spec_size,
-                                       fuse=FUSED_SPECT,
+                                       fuse=fuse,
                                        hop_length=hop_length, window_length=window_length)
 
     # Add dataloader
@@ -108,17 +119,20 @@ def transfer_learning(model=None, folders=None, strategy=0,
 
     # Finetune
     model = fine_tune_model(model=model, output_dim=len(classes_mapping),
-                            strategy=strategy, deepcopy=True)
+                            strategy=strategy, deepcopy=True, layers_freezed=layers_freezed)
 
     # use GPU if available
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"DEVICE: {device}")
-    # Send model to device
-    model.to('cpu')
-    print(model)
+
+    #model.to('cpu')
+
     print_require_grad_parameter(model)
 
-    # Add max_seq_length to model
+    # Send model to device
+    model.to(device)
+    print(model)
+    # Number of parameters to be updated
     print('Model parameters:{}'.format(sum(p.numel()
                                            for p in model.parameters()
                                            if p.requires_grad)))
@@ -126,41 +140,79 @@ def transfer_learning(model=None, folders=None, strategy=0,
     ##################################
     # TRAINING PIPELINE
     ##################################
-    loss_function = torch.nn.CrossEntropyLoss()
     optimizer = torch.optim.AdamW(params=model.parameters(),
                                   lr=0.001,
                                   weight_decay=.02)
 
-    best_model, train_losses, valid_losses, train_accuracy, \
-    valid_accuracy, valid_f1, _epochs = train_and_validate(model=model,
-                                                 train_loader=train_loader,
-                                                 valid_loader=valid_loader,
-                                                 loss_function=loss_function,
-                                                 optimizer=optimizer,
-                                                 epochs=EPOCHS,
-                                                 cnn=CNN_BOOLEAN,
-                                                 validation_epochs=5,
-                                                 early_stopping=True)
+    if task == "classification":
+        loss_function = torch.nn.CrossEntropyLoss()
+    else:
+        loss_function = torch.nn.MSELoss()
+
+
+    best_model, train_losses, valid_losses, \
+    train_metric, val_metric, \
+    val_comparison_metric, _epochs = train_and_validate(
+        model=model, train_loader=train_loader,
+        valid_loader=valid_loader,
+        loss_function=loss_function,
+        optimizer=optimizer,
+        epochs=EPOCHS,
+        task=task,
+        cnn=CNN_BOOLEAN,
+        validation_epochs=5,
+        early_stopping=True)
 
     timestamp = time.ctime()
-    model_id = f"{best_model.__class__.__name__}_{_epochs}_{timestamp}.pt"
+    timestamp = timestamp.replace(" ", "_")
+
+    if task == "classification":
+
+        print('All validation accuracies: {} \n'.format(val_metric))
+        best_index = val_comparison_metric.index(max(val_comparison_metric))
+        best_model_acc = val_metric[best_index]
+        print('Best model\'s validation accuracy: {}'.format(best_model_acc))
+        best_model_f1 = val_comparison_metric[best_index]
+        print('Best model\'s validation f1 score: {}'.format(best_model_f1))
+        best_model_loss = valid_losses[best_index]
+        print('Best model\'s validation loss: {}'.format(best_model_loss))
+
+    else:
+
+        print('All validation errors: {} \n'.format(val_comparison_metric))
+        best_index = val_comparison_metric.index(min(val_comparison_metric))
+        best_model_error = val_comparison_metric[best_index]
+        print('Best model\'s validation error: {}'.format(best_model_error))
+        best_model_loss = valid_losses[best_index]
+        print('Best model\'s validation loss: {}'.format(best_model_loss))
+
+
+    ofile = f"{best_model.__class__.__name__}_{_epochs}_{timestamp}.pt"
+
+    if not os.path.exists(VARIABLES_FOLDER):
+        os.makedirs(VARIABLES_FOLDER)
     modelname = os.path.join(
-        VARIABLES_FOLDER, model_id)
-    print(f"\nSaving model to: {model_id}\n")
-    # Save model for later use
+        VARIABLES_FOLDER, ofile)
 
+    print(f"\nSaving model to: {modelname}\n")
     best_model = best_model.to("cpu")
-
+    # Save model for later use
     model_params = {
-        "height": best_model.height, "width": best_model.width,  "classes_mapping": classes_mapping,
-        "output_dim": best_model.output_dim, "zero_pad": best_model.zero_pad, "spec_size": best_model.spec_size,
-        "fuse": best_model.fuse, "validation_f1": valid_f1, "max_sequence_length": best_model.max_sequence_length,
-        "type": best_model.type, "state_dict": best_model.state_dict()
+        "height": best_model.height, "width": best_model.width,
+        "zero_pad": zero_pad, "spec_size": spec_size, "fuse": fuse,
+        "max_sequence_length": max_seq_length,
+        "type": best_model.type, "state_dict": best_model.state_dict(), "window_length": window_length,
+        "hop_length": hop_length
     }
-
+    if task == "classification":
+        model_params["classes_mapping"] = classes_mapping
+        model_params["output_dim"] = len(classes_mapping)
+        model_params["validation_f1"] = best_model_f1
+    else:
+        model_params["representation_channels"] = best_model.representation_channels
+        model_params["validation_error"] = best_model_error
     with open(modelname, "wb") as output_file:
         pickle.dump(model_params, output_file)
-
 
 if __name__ == '__main__':
 
@@ -172,8 +224,11 @@ if __name__ == '__main__':
     parser.add_argument('-m', '--model', required=True, type=str,
                         help='Model to apply tranfer learning.')
 
-    parser.add_argument('-s', '--strategy', required=False, default=0, type=int,
-                        help='Strategy to apply in transfer learning: 0 or 1.')
+    parser.add_argument('-s', '--strategy', required=False, action='store_true',
+                        help='If added update only linear layers')
+
+    parser.add_argument('-l', '--layers_freezed', required=False, default=0,
+                        type=int, help='Number of final layers to freeze their weights')
 
     args = parser.parse_args()
 
@@ -181,7 +236,7 @@ if __name__ == '__main__':
     folders = args.input
     modelpath = args.model
     strategy = args.strategy
-
+    layers_freezed = args.layers_freezed
     # Fix any type errors
     folders = [f.replace(',', '').strip() for f in folders]
 
@@ -196,7 +251,7 @@ if __name__ == '__main__':
 
     # If everything is ok, time to start
     if FORCE_SIZE:
-        transfer_learning(model=modelpath, folders=folders,
-                          strategy=strategy, forced_size=SPECTOGRAM_SIZE)
+        transfer_learning(modelpath=modelpath, folders=folders,
+                          strategy=strategy, forced_size=SPECTOGRAM_SIZE, layers_freezed=layers_freezed)
     else:
-        transfer_learning(model=modelpath, folders=folders, strategy=strategy)
+        transfer_learning(modelpath=modelpath, folders=folders, strategy=strategy, layers_freezed=layers_freezed)

--- a/deep_audio_features/utils/model_editing.py
+++ b/deep_audio_features/utils/model_editing.py
@@ -79,8 +79,8 @@ Returns:
     return new_model
 
 
-def fine_tune_model(model=None, output_dim=None, strategy=0,
-                    deepcopy=False, *args, **kwargs):
+def fine_tune_model(model=None, output_dim=None, strategy=False,
+                    deepcopy=False, layers_freezed=0, *args, **kwargs):
     """Fine tune a given model.
 
 # Arguments:
@@ -91,8 +91,7 @@ def fine_tune_model(model=None, output_dim=None, strategy=0,
 
         strategy {int} :
 
-            * 0 : Return a model that updates all its
-                    weights and has new output dimension.
+            * 0 : Return a model that has freezed the first #layers_freezed layers.
 
             * 1 : Return a model that updates all its `Linear`
                     weights only and has new output dimension.
@@ -108,22 +107,20 @@ def fine_tune_model(model=None, output_dim=None, strategy=0,
         raise AttributeError()
     if deepcopy is True:
         model = copy.deepcopy(model)
+    if layers_freezed not in list(range(0, len(list(model.children()))+1)):
+        raise ArithmeticError(
+            f'Please check out the number of layers to '
+            f'be freezed ({layers_freezed}).')
 
-    if strategy == 0: # Train the entire model
-        # Get all layers
-        model_layers = [y for x in model.children() for y in x.children()]
-        if model_layers == []:
-            # Has not children level 2 => functional
-            FUNCTIONAL = True
-            raise NotImplementedError()
-        named_children = list(model.named_children())
 
-    elif strategy == 1: # Train only linear layers
+    # Get all layers
+    model_layers = [y for x in model.children() for y in x.children()]
+    if model_layers == []:
+        raise NotImplementedError()
+    named_children = list(model.named_children())
+
+    if strategy: # Train only linear layers
         # Freeze all layers except for the linear
-        model_layers = [y for x in model.children() for y in x.children()]
-        if model_layers == []:
-            raise NotImplementedError()
-        named_children = list(model.named_children())
         for seq_layername, seq_layer in named_children:
             # Find all Conv2d layers and freeze weights
             if any([isinstance(c, torch.nn.Conv2d)
@@ -138,6 +135,24 @@ def fine_tune_model(model=None, output_dim=None, strategy=0,
                         nested_layer.weight.requires_grad = False
                     except Exception as e:
                         raise e("Error while trying to turn off gradients.")
+    elif layers_freezed != 0:
+        # Freeze given number of layers
+        for i in range(layers_freezed):
+            seq_layername, seq_layer = named_children[i]
+            # Find all Conv2d or Linear layers and freeze weights
+            if any([isinstance(c, torch.nn.Conv2d) or isinstance(c, torch.nn.Linear)
+                    for c in seq_layer.children()]):
+                for nested_layer in seq_layer.children():
+                    # Skip all except Conv2d or Linear
+                    if not isinstance(nested_layer, torch.nn.Conv2d) and not isinstance(nested_layer, torch.nn.Linear):
+                        continue
+                    # Set grad off for bias as well as weights
+                    try:
+                        nested_layer.bias.requires_grad = False
+                        nested_layer.weight.requires_grad = False
+                    except Exception as e:
+                        raise e("Error while trying to turn off gradients.")
+
 
     for seq_layername, seq_layer in named_children[::-1]:
         if any([isinstance(c, torch.nn.Linear)

--- a/deep_audio_features/utils/model_editing.py
+++ b/deep_audio_features/utils/model_editing.py
@@ -15,7 +15,7 @@ Print whether a layer updates its weights or not.
     for ch1 in model.children():
         for layer in ch1.children():
             if isinstance(layer, torch.nn.Conv2d) or \
-                    isinstance(layer, torch.nn.Linear):
+                    isinstance(layer, torch.nn.Linear) or isinstance(layer, torch.nn.BatchNorm2d):
                 print(f"{layer} -> {layer.weight.requires_grad}")
     print("--------------------------------")
     print('\n\n')
@@ -123,11 +123,11 @@ def fine_tune_model(model=None, output_dim=None, strategy=False,
         # Freeze all layers except for the linear
         for seq_layername, seq_layer in named_children:
             # Find all Conv2d layers and freeze weights
-            if any([isinstance(c, torch.nn.Conv2d)
+            if any([isinstance(c, torch.nn.Conv2d) or isinstance(c, torch.nn.BatchNorm2d)
                     for c in seq_layer.children()]):
                 for nested_layer in seq_layer.children():
                     # Skip all except Conv2d
-                    if not isinstance(nested_layer, torch.nn.Conv2d):
+                    if not isinstance(nested_layer, torch.nn.Conv2d) and not isinstance(nested_layer, torch.nn.BatchNorm2d):
                         continue
                     # Set grad off for bias as well as weights
                     try:
@@ -140,11 +140,11 @@ def fine_tune_model(model=None, output_dim=None, strategy=False,
         for i in range(layers_freezed):
             seq_layername, seq_layer = named_children[i]
             # Find all Conv2d or Linear layers and freeze weights
-            if any([isinstance(c, torch.nn.Conv2d) or isinstance(c, torch.nn.Linear)
+            if any([isinstance(c, torch.nn.Conv2d) or isinstance(c, torch.nn.Linear) or isinstance(c, torch.nn.BatchNorm2d)
                     for c in seq_layer.children()]):
                 for nested_layer in seq_layer.children():
                     # Skip all except Conv2d or Linear
-                    if not isinstance(nested_layer, torch.nn.Conv2d) and not isinstance(nested_layer, torch.nn.Linear):
+                    if not isinstance(nested_layer, torch.nn.Conv2d) and not isinstance(nested_layer, torch.nn.Linear) and not isinstance(nested_layer, torch.nn.BatchNorm2d):
                         continue
                     # Set grad off for bias as well as weights
                     try:


### PR DESCRIPTION
This PR is responsible about making transfer learning work after convAE was added as well as enabling the user to define the number of layers he/she wants to be freezed in transfer learning procedure.

To see the pretrained model architecture before running transfer learning, follow the below command: 
`python3 deep_audio_features/bin/tool_model_architecture.py -m pretrained_model`

In order to test, run the following command: 
` python3 deep_audio_features/bin/transfer_learning.py -i paths -m model -l layers_freezed -s` 

where: 

- paths: is a list of data paths in which the model will be retrained 
- model: the pretrained model 
- layers_freezed: the number of layers to be freezed (counting from the beginning of the model architecture) 
- -s is an optional argument: if added then the -l argument is neglected, and only the linear layers will be updated. 